### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,8 +1,8 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
   <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" media="screen, projection" />
   <link rel="stylesheet" href="css/bootstrap/bootstrap-theme.min.css" media="screen, projection" />
   <link rel="stylesheet" href="css/options.css" />
@@ -42,7 +42,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-body">
-          <span class="i18n" id="changes_restart">However, some of your changes require the extension to be restarted. Would you like to do it now?<br>(This will reset your unread tweets count.)</span>
+          <span class="i18n" id="changes_restart">However, some of your changes require the extension to be restarted. Would you like to do it now?<br/>(This will reset your unread tweets count.)</span>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default i18n" data-dismiss="modal"id="d_restart_immediately">Restart immediately</button>
@@ -149,7 +149,7 @@
           <div class="col-md-4"><input type="checkbox" class="checkbox" id="show_user_autocomplete" name="show_user_autocomplete" /></div>
         </div>
         <div class="row form-group">
-          <div class="col-md-4 col-md-offset-8"><input type="button" class="i18n btn" value="Reset Popup Size" id="btn_reset_popup_size"></div>
+          <div class="col-md-4 col-md-offset-8"><input type="button" class="i18n btn" value="Reset Popup Size" id="btn_reset_popup_size"/></div>
         </div>
       </div>
     </div>
@@ -173,25 +173,25 @@
         </tr>
         <tr>
           <th class="i18n" id="l_visible">Visible</th>
-          <td><input type="checkbox" name="unified_visible" validator="unifiedValidator"></td>
-          <td><input type="checkbox" name="home_visible"></td>
-          <td><input type="checkbox" name="mentions_visible"></td>
-          <td><input type="checkbox" name="dms_visible"></td>
-          <td><input type="checkbox" name="lists_visible"></td>
-          <td><input type="checkbox" name="search_visible"></td>
-          <td><input type="checkbox" name="likes_visible"></td>
+          <td><input type="checkbox" name="unified_visible" validator="unifiedValidator"/></td>
+          <td><input type="checkbox" name="home_visible"/></td>
+          <td><input type="checkbox" name="mentions_visible"/></td>
+          <td><input type="checkbox" name="dms_visible"/></td>
+          <td><input type="checkbox" name="lists_visible"/></td>
+          <td><input type="checkbox" name="search_visible"/></td>
+          <td><input type="checkbox" name="likes_visible"/></td>
           <td>&nbsp;</td>
         </tr>
         <tr>
           <th class="i18n" id="l_include_in_unified">Include in unified timeline</th>
           <td>&nbsp;</td>
-          <td><input type="checkbox" name="home_include_unified"></td>
-          <td><input type="checkbox" name="mentions_include_unified"></td>
-          <td><input type="checkbox" name="dms_include_unified"></td>
-          <td><input type="checkbox" name="lists_include_unified"></td>
-          <td><input type="checkbox" name="search_include_unified"></td>
-          <td><input type="checkbox" name="likes_include_unified"></td>
-          <td><input type="checkbox" name="notification_include_unified"></td>
+          <td><input type="checkbox" name="home_include_unified"/></td>
+          <td><input type="checkbox" name="mentions_include_unified"/></td>
+          <td><input type="checkbox" name="dms_include_unified"/></td>
+          <td><input type="checkbox" name="lists_include_unified"/></td>
+          <td><input type="checkbox" name="search_include_unified"/></td>
+          <td><input type="checkbox" name="likes_include_unified"/></td>
+          <td><input type="checkbox" name="notification_include_unified"/></td>
         </tr>
         <tr>
           <th class="i18n" id="l_exclude_blocked_and_muted">Allow to exclude blocked or muted users</th>
@@ -199,8 +199,8 @@
           <td>-</td>
           <td>-</td>
           <td>-</td>
-          <td><input type="checkbox" name="lists_exclude_blocked_muted" must_restart></td>
-          <td><input type="checkbox" name="search_exclude_blocked_muted" must_restart></td>
+          <td><input type="checkbox" name="lists_exclude_blocked_muted" must_restart/></td>
+          <td><input type="checkbox" name="search_exclude_blocked_muted" must_restart/></td>
           <td>-</td>
           <td>&nbsp;</td>
         </tr>
@@ -211,7 +211,7 @@
           <td>-</td>
           <td>-</td>
           <td>-</td>
-          <td><input type="checkbox" name="search_exclude_retweet" must_restart></td>
+          <td><input type="checkbox" name="search_exclude_retweet" must_restart/></td>
           <td>-</td>
           <td>&nbsp;</td>
         </tr>
@@ -255,8 +255,8 @@
       <div class="panel-body">
         <div class="row form-group">
           <div class="col-md-4"><label for="tweets_notification_style" class="i18n" id="l_tweets_notification_style">Notification Style</label></div>
-          <div class="col-md-4"><input type="radio" name="tweets_notification_style" value="never" id="noti_never"> <label for="noti_never" class="i18n" id="l_noti_never">Never</label></div>
-          <div class="col-md-4"><input type="radio" name="tweets_notification_style" value="desktop" id="noti_desktop"> <label for="noti_desktop" class="i18n" id="l_noti_desktop">Desktop Notifications</label></div>
+          <div class="col-md-4"><input type="radio" name="tweets_notification_style" value="never" id="noti_never"/> <label for="noti_never" class="i18n" id="l_noti_never">Never</label></div>
+          <div class="col-md-4"><input type="radio" name="tweets_notification_style" value="desktop" id="noti_desktop"/> <label for="noti_desktop" class="i18n" id="l_noti_desktop">Desktop Notifications</label></div>
         </div>
         <div class="notify_options">
           <div class="row form-group">
@@ -280,11 +280,11 @@
         </tr>
         <tr>
           <th class="i18n" id="l_tweet_notificacion">Tweet Notification</th>
-          <td><input type="checkbox" name="home_notify"></td>
-          <td><input type="checkbox" name="mentions_notify"></td>
-          <td><input type="checkbox" name="dms_notify"></td>
-          <td><input type="checkbox" name="lists_notify"></td>
-          <td><input type="checkbox" name="search_notify"></td>
+          <td><input type="checkbox" name="home_notify"/></td>
+          <td><input type="checkbox" name="mentions_notify"/></td>
+          <td><input type="checkbox" name="dms_notify"/></td>
+          <td><input type="checkbox" name="lists_notify"/></td>
+          <td><input type="checkbox" name="search_notify"/></td>
         </tr>
       </table>
     </div>
@@ -301,7 +301,7 @@
         </div>
         <div class="row form-group">
           <div class="col-md-8"><label for="share_include_title" class="i18n" id="l_share_include_title">Include page title (sharing)</label></div>
-          <div class="col-md-4"><input type="checkbox" class="checkbox" name="share_include_title"></div>
+          <div class="col-md-4"><input type="checkbox" class="checkbox" name="share_include_title"/></div>
         </div>
       </div>
     </div>

--- a/popup.html
+++ b/popup.html
@@ -57,7 +57,7 @@
       <span id="suspend_status" class="i18n glyphicon glyphicon-stop" title="Click to Resume"></span>
       <span id="stream_status" class="i18n glyphicon glyphicon-pause" title="Connect UserStream"></span>
       <span id="detach_window" class="i18n glyphicon glyphicon-eject" title="Detach window"></span>
-      <a id="twitter_link" href="#"><img id="view_twitter" src="img/twitter-bird-16x16.png" class="i18n" title="View Twitter" ></a>
+      <a id="twitter_link" href="#"><img id="view_twitter" src="img/twitter-bird-16x16.png" class="i18n" title="View Twitter" /></a>
     </div>
   </div>
   <div id="tabs"><ul></ul></div>

--- a/template/enterpin.html
+++ b/template/enterpin.html
@@ -1,9 +1,9 @@
 <template id="templateEnterPin">
   <div id="enter_pin" style="">
     <label for="input_pin">Twitter's OAuth Pin:<span id="loading_oauth" class="i18n glyphicon glyphicon-repeat"></span></label>
-    <input type="text" name="input_pin" id="input_pin"></input>
-    <input type="button" class="i18n" id="btnAuthorize" value="Authorize!"></input>
-    <input type="button" class="i18n" id="newToken" value="Get New Token"></input>
+    <input type="text" name="input_pin" id="input_pin"/></input>
+    <input type="button" class="i18n" id="btnAuthorize" value="Authorize!"/></input>
+    <input type="button" class="i18n" id="newToken" value="Get New Token"/></input>
   </div>
   <div id="error_pin"></div>
 </template>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code, and the only changes that have been made is closing of void elements.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
